### PR TITLE
Add application name to the logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ import (
 
 func main() {
         log := logrus.New()
-        hook, err := logrus_logstash.NewHook("tcp", "172.17.0.2:9999")
+        hook, err := logrus_logstash.NewHook("tcp", "172.17.0.2:9999", "myappName")
         if err != nil {
                 log.Fatal(err)
         }
         log.Hooks.Add(hook)
-        ctx := ctx := log.WithFields(logrus.Fields{
+        ctx := log.WithFields(logrus.Fields{
           "method": "main",
         })
         ...
@@ -36,6 +36,7 @@ This is how it will look like:
        "message" => "Hello World!",
         "method" => "main",
           "host" => "172.17.0.1",
-          "port" => 45199
+          "port" => 45199,
+          "type" => "myappName"
 }
 ```

--- a/logstash.go
+++ b/logstash.go
@@ -9,21 +9,22 @@ import (
 
 // Hook represents a connection to a Logstash instance
 type Hook struct {
-	conn net.Conn
+	conn    net.Conn
+	appName string
 }
 
 // NewHook creates a new hook to a Logstash instance, which listens on
 // `protocol`://`address`.
-func NewHook(protocol, address string) (*Hook, error) {
+func NewHook(protocol, address, appName string) (*Hook, error) {
 	conn, err := net.Dial(protocol, address)
 	if err != nil {
 		return nil, err
 	}
-	return &Hook{conn: conn}, nil
+	return &Hook{conn: conn, appName: appName}, nil
 }
 
 func (h *Hook) Fire(entry *logrus.Entry) error {
-	formatter := logrus_logstash_fmt.LogstashFormatter{}
+	formatter := logrus_logstash_fmt.LogstashFormatter{Type: h.appName}
 	dataBytes, err := formatter.Format(entry)
 	if err != nil {
 		return err


### PR DESCRIPTION
A common idiom is to specify the app name in the logstash arguments. That adds a "type" field to the created JSON.