### PR TITLE
Move formatter from logrus

### DIFF
--- a/logstash.go
+++ b/logstash.go
@@ -4,7 +4,6 @@ import (
 	"net"
 
 	"github.com/Sirupsen/logrus"
-	logrus_logstash_fmt "github.com/Sirupsen/logrus/formatters/logstash"
 )
 
 // Hook represents a connection to a Logstash instance
@@ -24,7 +23,7 @@ func NewHook(protocol, address, appName string) (*Hook, error) {
 }
 
 func (h *Hook) Fire(entry *logrus.Entry) error {
-	formatter := logrus_logstash_fmt.LogstashFormatter{Type: h.appName}
+	formatter := LogstashFormatter{Type: h.appName}
 	dataBytes, err := formatter.Format(entry)
 	if err != nil {
 		return err

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -1,4 +1,4 @@
-package logstash
+package logrus_logstash
 
 import (
 	"encoding/json"

--- a/logstash_formatter_test.go
+++ b/logstash_formatter_test.go
@@ -1,4 +1,4 @@
-package logstash
+package logrus_logstash
 
 import (
 	"bytes"


### PR DESCRIPTION
This comes from this discussion: https://github.com/Sirupsen/logrus/pull/378#issuecomment-232025447

@Sirupsen wants to move the logstash formatter out to a different repository, and I thought that it would be easier to maintain the formatter as part of this hook repository. 

I realize I'm handing off the maintenance cost, but I feel like it does reduce the overall maintenance cost.

To be clear, there are at least two PRs pending in the logrus repository that change the formatter:
 - https://github.com/Sirupsen/logrus/pull/378
 - https://github.com/Sirupsen/logrus/pull/354

Thoughts?