### PR TITLE
TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+sudo: false
+
+matrix:
+  include:
+    - go: 1.3
+    - go: 1.4
+    - go: 1.5
+    - go: 1.6
+    - go: tip
+
+install:
+  - # Skip
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Logstash hook for logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" />
+# Logstash hook for logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" /> [![Build Status](https://travis-ci.org/bshuster-repo/logrus-logstash-hook.svg?branch=master)](https://travis-ci.org/bshuster-repo/logrus-logstash-hook)
 Use this hook to send the logs to [Logstash](https://www.elastic.co/products/logstash) over both UDP and TCP.
 
 ## Usage


### PR DESCRIPTION
Adding simple travis support:
 - Builds the same set of golang versions that logrus does
 - Runs: go fmt, go test, and go vet
 - Adds a build badge 

Requires [travis](https://travis-ci.org/) be connected to the bshuster-repo organization, and enabled for this repo. 