### PR TITLE
Check for error types in logstash formatter

### DIFF
--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -19,7 +19,14 @@ type LogstashFormatter struct {
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
-		fields[k] = v
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			// https://github.com/Sirupsen/logrus/issues/377
+			fields[k] = v.Error()
+		default:
+			fields[k] = v
+		}
 	}
 
 	fields["@version"] = 1

--- a/logstash_formatter_test.go
+++ b/logstash_formatter_test.go
@@ -23,7 +23,7 @@ func TestLogstashFormatter(t *testing.T) {
 		"one":     1,
 		"pi":      3.14,
 		"bool":    true,
-		"error":   url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")},
+		"error":   &url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")},
 	}
 
 	entry := logrus.WithFields(fields)
@@ -43,7 +43,7 @@ func TestLogstashFormatter(t *testing.T) {
 	assert.Equal("abc", data["type"])
 	assert.Equal("msg", data["message"])
 	assert.Equal("info", data["level"])
-	assert.Equal("Get http://example.com The error", data["error"])
+	assert.Equal("Get http://example.com: The error", data["error"])
 
 	// substituted fields
 	assert.Equal("def", data["fields.message"])

--- a/logstash_formatter_test.go
+++ b/logstash_formatter_test.go
@@ -3,9 +3,12 @@ package logrus_logstash
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"net/url"
+	"testing"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestLogstashFormatter(t *testing.T) {
@@ -20,6 +23,7 @@ func TestLogstashFormatter(t *testing.T) {
 		"one":     1,
 		"pi":      3.14,
 		"bool":    true,
+		"error":   url.Error{Op: "Get", URL: "http://example.com", Err: fmt.Errorf("The error")},
 	}
 
 	entry := logrus.WithFields(fields)
@@ -39,6 +43,7 @@ func TestLogstashFormatter(t *testing.T) {
 	assert.Equal("abc", data["type"])
 	assert.Equal("msg", data["message"])
 	assert.Equal("info", data["level"])
+	assert.Equal("Get http://example.com The error", data["error"])
 
 	// substituted fields
 	assert.Equal("def", data["fields.message"])


### PR DESCRIPTION
Check for `error` type to correctly serialise errors.

See https://github.com/Sirupsen/logrus/issues/377

(this is my attempt to cherry-pick this PR https://github.com/Sirupsen/logrus/pull/378)