### PR TITLE
Allow setting appFields that are sent with every log entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -22,3 +23,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.iml

--- a/logstash.go
+++ b/logstash.go
@@ -8,23 +8,24 @@ import (
 
 // Hook represents a connection to a Logstash instance
 type Hook struct {
-	conn    net.Conn
-	appName string
+	conn      net.Conn
+	appName   string
+	appFields logrus.Fields
 }
 
 // NewHook creates a new hook to a Logstash instance, which listens on
 // `protocol`://`address`.
-func NewHook(protocol, address, appName string) (*Hook, error) {
+func NewHook(protocol, address, appName string, appFields logrus.Fields) (*Hook, error) {
 	conn, err := net.Dial(protocol, address)
 	if err != nil {
 		return nil, err
 	}
-	return &Hook{conn: conn, appName: appName}, nil
+	return &Hook{conn: conn, appName: appName, appFields: appFields}, nil
 }
 
 func (h *Hook) Fire(entry *logrus.Entry) error {
 	formatter := LogstashFormatter{Type: h.appName}
-	dataBytes, err := formatter.Format(entry)
+	dataBytes, err := formatter.Format(entry, h.appFields)
 	if err != nil {
 		return err
 	}

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -16,8 +16,12 @@ type LogstashFormatter struct {
 	TimestampFormat string
 }
 
-func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+func (f *LogstashFormatter) Format(entry *logrus.Entry, appFields logrus.Fields) ([]byte, error) {
 	fields := make(logrus.Fields)
+	for k, v := range appFields {
+		fields[k] = v
+	}
+
 	for k, v := range entry.Data {
 		switch v := v.(type) {
 		case error:


### PR DESCRIPTION
I understand you might not want this for backwards compatibility issues but we find it useful to send things like the hostname or docker container id with every log entry to make it easier to find stuff.

Usage

```go
hook, err := logrus_logstash.NewHook("udp", "logstashAddr", "appName", logrus.Fields{
	"hostname": "hostname.com",
	"serviceName": "my-service",
})
```