### PR TITLE
Allow setting fields that are sent with every log entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -22,3 +23,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+*.iml

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ import (
 func main() {
         log := logrus.New()
         hook, err := logrus_logstash.NewHook("tcp", "172.17.0.2:9999", "myappName")
+        // OR use NewHookWithFields to always send specific fields with every log entry
+        hook, err := logrus_logstash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
+                "hostname":    os.Hostname(),
+                "serviceName": "myServiceName",
+        })
         if err != nil {
                 log.Fatal(err)
         }

--- a/logstash.go
+++ b/logstash.go
@@ -8,22 +8,36 @@ import (
 
 // Hook represents a connection to a Logstash instance
 type Hook struct {
-	conn    net.Conn
-	appName string
+	conn             net.Conn
+	appName          string
+	alwaysSentFields logrus.Fields
 }
 
 // NewHook creates a new hook to a Logstash instance, which listens on
 // `protocol`://`address`.
 func NewHook(protocol, address, appName string) (*Hook, error) {
+	return NewHookWithFields(protocol, address, appName, make(logrus.Fields))
+}
+
+// NewHookWithFields creates a new hook to a Logstash instance, which listens on
+// `protocol`://`address`. alwaysSentFields will be sent with every log entry.
+func NewHookWithFields(protocol, address, appName string, alwaysSentFields logrus.Fields) (*Hook, error) {
 	conn, err := net.Dial(protocol, address)
 	if err != nil {
 		return nil, err
 	}
-	return &Hook{conn: conn, appName: appName}, nil
+	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields}, nil
 }
 
 func (h *Hook) Fire(entry *logrus.Entry) error {
 	formatter := LogstashFormatter{Type: h.appName}
+
+	// Add in the alwaysSentFields. We don't override fields that are already set.
+	for k, v := range h.alwaysSentFields {
+		if _, inMap := entry.Data[k]; !inMap {
+			entry.Data[k] = v
+		}
+	}
 	dataBytes, err := formatter.Format(entry)
 	if err != nil {
 		return err


### PR DESCRIPTION
Maintains backwards compatibility by adding a new method (as suggested) `NewHookWithFields`