### PR TITLE
Added prefix filtering and better alwayssentFields support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,7 @@ import (
 func main() {
         log := logrus.New()
         hook, err := logrus_logstash.NewHook("tcp", "172.17.0.2:9999", "myappName")
-        // OR use NewHookWithFields to always send specific fields with every log entry
-        hook, err := logrus_logstash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
-                "hostname":    os.Hostname(),
-                "serviceName": "myServiceName",
-        })
+
         if err != nil {
                 log.Fatal(err)
         }
@@ -45,3 +41,55 @@ This is how it will look like:
           "type" => "myappName"
 }
 ```
+## Hook Fields
+Fields can be added to the hook, which will always be in the log context.
+This can be done when creating the hook:
+
+```go
+
+hook, err := logrus_logstash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
+        "hostname":    os.Hostname(),
+        "serviceName": "myServiceName",
+})
+```
+
+Or afterwards:
+
+```go
+
+hook.WithFields(logrus.Fields{
+        "hostname":    os.Hostname(),
+        "serviceName": "myServiceName",
+})
+```
+This allows you to set up the hook so logging is available immediately, and add important fields as they become available.
+
+Single fields can be added/updated using 'WithField':
+
+```go
+
+hook.WithField("status", "running")
+```
+
+
+
+## Field prefix
+
+The hook allows you to send logging to logstash and also retain the default std output in text format.
+However to keep this console output readable some fields might need to be omitted from the default non-hooked log output.
+Each hook can be configured with a prefix used to identify fields which are only to be logged to the logstash connection.
+For example we if you don't want to see the hostname and serviceName on each log line in the console output you can add a prefix:
+
+```go
+
+
+hook, err := logrus_logstash.NewHookWithFields("tcp", "172.17.0.2:9999", "myappName", logrus.Fields{
+        "_hostname":    os.Hostname(),
+        "_serviceName": "myServiceName",
+})
+...
+hook.WithPrefix("_")
+```
+
+There are also constructors available which allow you to specify the prefix from the start.
+The std-out will not have the '\_hostname' and '\_servicename' fields, and the logstash output will, but the prefix will be dropped from the name.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ hook.WithField("status", "running")
 The hook allows you to send logging to logstash and also retain the default std output in text format.
 However to keep this console output readable some fields might need to be omitted from the default non-hooked log output.
 Each hook can be configured with a prefix used to identify fields which are only to be logged to the logstash connection.
-For example we if you don't want to see the hostname and serviceName on each log line in the console output you can add a prefix:
+For example if you don't want to see the hostname and serviceName on each log line in the console output you can add a prefix:
 
 ```go
 

--- a/logstash.go
+++ b/logstash.go
@@ -2,6 +2,7 @@ package logrus_logstash
 
 import (
 	"net"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -11,6 +12,7 @@ type Hook struct {
 	conn             net.Conn
 	appName          string
 	alwaysSentFields logrus.Fields
+	hookOnlyPrefix   string
 }
 
 // NewHook creates a new hook to a Logstash instance, which listens on
@@ -27,21 +29,58 @@ func NewHookWithConn(conn net.Conn, appName string) (*Hook, error) {
 // NewHookWithFields creates a new hook to a Logstash instance, which listens on
 // `protocol`://`address`. alwaysSentFields will be sent with every log entry.
 func NewHookWithFields(protocol, address, appName string, alwaysSentFields logrus.Fields) (*Hook, error) {
+	return NewHookWithFieldsAndPrefix(protocol, address, appName, alwaysSentFields, "")
+}
+
+func NewHookWithFieldsAndPrefix(protocol, address, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
 	conn, err := net.Dial(protocol, address)
 	if err != nil {
 		return nil, err
 	}
-	return NewHookWithFieldsAndConn(conn, appName, alwaysSentFields)
+	return NewHookWithFieldsAndConnAndPrefix(conn, appName, alwaysSentFields, prefix)
 }
 
 // NewHookWithFieldsAndConn creates a new hook to a Logstash instance using the supplied connection
 //The new Hook
 func NewHookWithFieldsAndConn(conn net.Conn, appName string, alwaysSentFields logrus.Fields) (*Hook, error) {
-	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields}, nil
+	return NewHookWithFieldsAndConnAndPrefix(conn, appName, alwaysSentFields, "")
+}
+
+func NewHookWithFieldsAndConnAndPrefix(conn net.Conn, appName string, alwaysSentFields logrus.Fields, prefix string) (*Hook, error) {
+	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields, hookOnlyPrefix: prefix}, nil
+}
+
+func (h *Hook) filterHookOnly(entry *logrus.Entry) {
+	if h.hookOnlyPrefix != "" {
+		for key := range entry.Data {
+			if strings.HasPrefix(key, h.hookOnlyPrefix) {
+				delete(entry.Data, key)
+			}
+		}
+	}
+
+}
+
+func (h *Hook) WithPrefix(prefix string) {
+	h.hookOnlyPrefix = prefix
+}
+
+func (h *Hook) WithField(key string, value interface{}) {
+	h.alwaysSentFields[key] = value
+}
+
+func (h *Hook) WithFields(fields logrus.Fields) {
+	//Add all the new fields to the 'alwaysSentFields', possibly overwriting exising fields
+	for key, value := range fields {
+		h.alwaysSentFields[key] = value
+	}
 }
 
 func (h *Hook) Fire(entry *logrus.Entry) error {
-	formatter := LogstashFormatter{Type: h.appName}
+	//make sure we always clear the hookonly fields from the entry
+	defer h.filterHookOnly(entry)
+
+	formatter := LogstashFormatter{Type: h.appName, Hook: h}
 
 	// Add in the alwaysSentFields. We don't override fields that are already set.
 	for k, v := range h.alwaysSentFields {

--- a/logstash.go
+++ b/logstash.go
@@ -50,13 +50,14 @@ func NewHookWithFieldsAndConnAndPrefix(conn net.Conn, appName string, alwaysSent
 	return &Hook{conn: conn, appName: appName, alwaysSentFields: alwaysSentFields, hookOnlyPrefix: prefix}, nil
 }
 
-//Make a new hook which does not forward to logstash, bu simply enforces the prefix rules
-func NewFilterHook() (*Hook, error) {
+//Make a new hook which does not forward to logstash, but simply enforces the prefix rules
+func NewFilterHook() *Hook {
 	return NewFilterHookWithPrefix("")
 }
 
-func NewFilterHookWithPrefix(prefix string) (*Hook, error) {
-	return &Hook{conn: nil, appName: "", alwaysSentFields: make(logrus.Fields), hookOnlyPrefix: prefix}, nil
+//Make a new hook which does not forward to logstash, but simply enforces the specified prefix
+func NewFilterHookWithPrefix(prefix string) *Hook {
+	return &Hook{conn: nil, appName: "", alwaysSentFields: make(logrus.Fields), hookOnlyPrefix: prefix}
 }
 
 func (h *Hook) filterHookOnly(entry *logrus.Entry) {
@@ -101,7 +102,7 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 		return nil
 	}
 
-	formatter := LogstashFormatter{Type: h.appName, Hook: h}
+	formatter := LogstashFormatter{Type: h.appName, HookOnlyPrefix: h.hookOnlyPrefix}
 
 	dataBytes, err := formatter.Format(entry)
 	if err != nil {

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -16,19 +16,15 @@ type LogstashFormatter struct {
 	// TimestampFormat sets the format used for timestamps.
 	TimestampFormat string
 
-	Hook *Hook
+	HookOnlyPrefix string
 }
 
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	prefix := ""
-	if f.Hook != nil {
-		prefix = f.Hook.hookOnlyPrefix
-	}
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
 		//remvove the prefix when sending the fields to logstash
-		if prefix != "" && strings.HasPrefix(k, prefix) {
-			k = strings.TrimPrefix(k, prefix)
+		if f.HookOnlyPrefix != "" && strings.HasPrefix(k, f.HookOnlyPrefix) {
+			k = strings.TrimPrefix(k, f.HookOnlyPrefix)
 		}
 
 		switch v := v.(type) {

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -15,16 +15,18 @@ type LogstashFormatter struct {
 
 	// TimestampFormat sets the format used for timestamps.
 	TimestampFormat string
-
-	HookOnlyPrefix string
 }
 
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return f.FormatWithPrefix(entry, "")
+}
+
+func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string) ([]byte, error) {
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
 		//remvove the prefix when sending the fields to logstash
-		if f.HookOnlyPrefix != "" && strings.HasPrefix(k, f.HookOnlyPrefix) {
-			k = strings.TrimPrefix(k, f.HookOnlyPrefix)
+		if prefix != "" && strings.HasPrefix(k, prefix) {
+			k = strings.TrimPrefix(k, prefix)
 		}
 
 		switch v := v.(type) {

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -20,7 +20,10 @@ type LogstashFormatter struct {
 }
 
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	prefix := f.Hook.hookOnlyPrefix
+	prefix := ""
+	if f.Hook != nil {
+		prefix = f.Hook.hookOnlyPrefix
+	}
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
 		//remvove the prefix when sending the fields to logstash

--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -3,6 +3,7 @@ package logrus_logstash
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -14,11 +15,19 @@ type LogstashFormatter struct {
 
 	// TimestampFormat sets the format used for timestamps.
 	TimestampFormat string
+
+	Hook *Hook
 }
 
 func (f *LogstashFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	prefix := f.Hook.hookOnlyPrefix
 	fields := make(logrus.Fields)
 	for k, v := range entry.Data {
+		//remvove the prefix when sending the fields to logstash
+		if prefix != "" && strings.HasPrefix(k, prefix) {
+			k = strings.TrimPrefix(k, prefix)
+		}
+
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`


### PR DESCRIPTION
Added Prefix support: Each hook has a configurable prefix. All fields which start with this prefix will only be included in the logstash log and not in later hooks and std logrus output. The fieldnames sent to logstash will also have the prefix trimmed.

Added WithFields and WithField functions to the hooks, so the alwaysSentFields can be updated after the hook has been created. This way information cna be incorporated that is not available yet at the moment logging is configured.

Readme was updated to reflect these changes
