### PR TITLE
Use time format with milliseconds

### DIFF
--- a/logstash_formatter.go
+++ b/logstash_formatter.go
@@ -44,7 +44,8 @@ func (f *LogstashFormatter) FormatWithPrefix(entry *logrus.Entry, prefix string)
 	timeStampFormat := f.TimestampFormat
 
 	if timeStampFormat == "" {
-		timeStampFormat = logrus.DefaultTimestampFormat
+		//timeStampFormat = logrus.DefaultTimestampFormat
+		timeStampFormat = "2006-01-02 15:04:05.000"
 	}
 
 	fields["@timestamp"] = entry.Time.Format(timeStampFormat)


### PR DESCRIPTION
Current implementation logrus-logstash-hook uses timeformat without milliseconds and does not have api to change the timeformat for use. Milliseconds in timestamps are really necessary - if server has to process more than one request per second and for every request it prints several messages - then without milliseconds everything is messed (in ELK) and almost impossible to follow the messages chronologically to analyze.