### PR TITLE
Add a way to set different time formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4
 
  * Update the name of the package from `logrus_logstash` to `logrustash`.
+ * Add TimeFormat to Hook
 
 ## 0.3
 

--- a/logstash.go
+++ b/logstash.go
@@ -13,6 +13,7 @@ type Hook struct {
 	appName          string
 	alwaysSentFields logrus.Fields
 	hookOnlyPrefix   string
+	TimeFormat       string
 }
 
 // NewHook creates a new hook to a Logstash instance, which listens on
@@ -106,6 +107,9 @@ func (h *Hook) Fire(entry *logrus.Entry) error {
 	}
 
 	formatter := LogstashFormatter{Type: h.appName}
+	if h.TimeFormat != "" {
+		formatter.TimestampFormat = h.TimeFormat
+	}
 
 	dataBytes, err := formatter.FormatWithPrefix(entry, h.hookOnlyPrefix)
 	if err != nil {

--- a/logstash_test.go
+++ b/logstash_test.go
@@ -297,3 +297,24 @@ func TestLevels(t *testing.T) {
 	}
 
 }
+
+func TestLogstashTimeStampFormat(t *testing.T) {
+	conn := ConnMock{buff: bytes.NewBufferString("")}
+	hook := &Hook{
+		conn:       conn,
+		TimeFormat: time.Kitchen,
+	}
+	fTime := time.Date(2009, time.November, 10, 3, 4, 0, 0, time.UTC)
+	if err := hook.Fire(&logrus.Entry{Time: fTime}); err != nil {
+		t.Errorf("expected fire to not return error: %s", err)
+	}
+	var res map[string]string
+	if err := json.NewDecoder(conn.buff).Decode(&res); err != nil {
+		t.Error(err)
+	}
+	if value, ok := res["@timestamp"]; !ok {
+		t.Error("expected result to have '@timestamp'")
+	} else if value != "3:04AM" {
+		t.Errorf("expected time to be '%s' but got '%s'", "3:04AM", value)
+	}
+}


### PR DESCRIPTION
closes #26 

An example:
```golang
hook, err := logrus_logstash.NewHook("tcp", "172.17.0.2:9999", "myappName")
hook.TimeFormat = time.RFC3339Nano
...
```