### PR TITLE
Reverted logrus package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Remove the old API: `NewConnWith`, `WithPrefix` and etc and move to a simple `New` function.
  * Prefix is no longer supported in this package.
  * Change the Hook structure to have only two members: `logrus.Formatter` and `io.Writer`.
+ * Reverted original logrus package path to `github.com/Sirupsen/logrus` because this caused backward compatibility issue and [was reverted](https://github.com/sirupsen/logrus/issues/451#issuecomment-264332021)
 
 ## 0.4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ package main
 import (
         "log"
 
-        "github.com/sirupsen/logrus"
+        "github.com/Sirupsen/logrus"
         "github.com/bshuster-repo/logrus-logstash-hook"
 )
 

--- a/functional_test.go
+++ b/functional_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/bshuster-repo/logrus-logstash-hook"
-	"github.com/sirupsen/logrus"
 )
 
 func TestEntryIsNotChangedByLogstashFormatter(t *testing.T) {

--- a/hook.go
+++ b/hook.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 // Hook represents a Logstash hook.

--- a/hook_test.go
+++ b/hook_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 type simpleFmter struct{}


### PR DESCRIPTION
It was reverted in `logrus` as causing lots of problems with backward compatibility. So reverting here as it causes installation problem either.