### PR TITLE
Update functional and unit tests

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -69,7 +69,7 @@ func TestTextFormatLogstash(t *testing.T) {
 
 	log.Warning("this is a warning message!")
 	mTime := time.Now()
-	expected := fmt.Sprintf(`time="%s" level=warning msg="this is a warning message!" HOSTNAME=localhost USERNAME=root 
+	expected := fmt.Sprintf(`time="%s" level=warning msg="this is a warning message!" HOSTNAME=localhost USERNAME=root
 `, mTime.Format(time.Kitchen))
 	if buffer.String() != expected {
 		t.Errorf("expected JSON to be '%#v' but got '%#v'", expected, buffer.String())

--- a/hook_test.go
+++ b/hook_test.go
@@ -125,7 +125,7 @@ func TestDefaultFormatterWithEmptyFields(t *testing.T) {
 		"\"Key1\":\"Value1\"",
 		"\"@version\":\"1\"",
 		"\"type\":\"log\"",
-		fmt.Sprintf("\"@timestamp\":\"%s\"", now.Format(logrus.DefaultTimestampFormat)),
+		fmt.Sprintf("\"@timestamp\":\"%s\"", now.Format(time.RFC3339)),
 	}
 
 	for _, exp := range expected {


### PR DESCRIPTION
Updated `TestTextFormatLogstash` as the new `logrus` version doesn't append a space in the end of line.
In addition, `logrus.DefaultTimestampFormat` was removed and instead using `time.RFC3339`.