### PR TITLE
fix module naming in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bshuster-repo/logrus-logstash-hook
+module github.com/bshuster-repo/logrus-logstash-hook
 
 go 1.16
 


### PR DESCRIPTION
The module name needs to start with a url, usually of the
service that hosts the repo. Otherwise it can't be fetched without
adding replace directives in users' go.mod files, for example:

go get: github.com/bshuster-repo/logrus-logstash-hook@v1.0.0 updating to
github.com/bshuster-repo/logrus-logstash-hook@v1.0.1: parsing go.mod:
module declares its path as: bshuster-repo/logrus-logstash-hook
       but was required as: github.com/bshuster-repo/logrus-logstash-hook