### PR TITLE
Without copying Caller and Logger into the new log entry, JSONFormatt…

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -67,6 +67,8 @@ func copyEntry(e *logrus.Entry, fields logrus.Fields) *logrus.Entry {
 	ne.Data = logrus.Fields{}
 
 	if e.HasCaller() {
+		ne.Caller = e.Caller
+		ne.Logger = e.Logger
 		ne.Data["function"] = e.Caller.Function
 		ne.Data["file"] = fmt.Sprintf("%s:%d", e.Caller.File, e.Caller.Line)
 	}


### PR DESCRIPTION
…er does not detect that the entry has a caller, so it doesn't transform the _file_ and _function_ field keys basing on the FieldMap.

That clashes with the schema accepted by our ElasticSearch, which then drops the logs entry.